### PR TITLE
Added latin chars to regexp

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -3,8 +3,8 @@ var fs = require( 'fs' )
   , extractorPath = path.join( __dirname, "extractors" )
   , typeExtractors = {}
   , regexExtractors = []
-  , preserveLineBreaks = /[^A-Za-z 0-9 \.,\?""!@#\$%\^&\*\(\)-_=\+;:<>\/\\\|\}\{\[\]`~'\n\r]*/g
-  , stripLineBreaks = /[^A-Za-z 0-9 \.,\?""!@#\$%\^&\*\(\)-_=\+;:<>\/\\\|\}\{\[\]`~']*/g
+  , preserveLineBreaks = /[^A-Za-z\x80-\xFF 0-9 \.,\?""!@#\$%\^&\*\(\)-_=\+;:<>\/\\\|\}\{\[\]`~'\n\r]*/g
+  , stripLineBreaks = /[^A-Za-z\x80-\xFF 0-9 \.,\?""!@#\$%\^&\*\(\)-_=\+;:<>\/\\\|\}\{\[\]`~']*/g
   , extractors = []
   , totalExtractors = 0
   , satisfiedExtractors = 0;

--- a/lib/extractors/docx.js
+++ b/lib/extractors/docx.js
@@ -8,7 +8,7 @@ var extractText = function( filePath, options, cb ) {
     , SINGLE_QUOTES = /[\u2018|\u2019]/g
     , DOUBLE_QUOTES = /[\u201C|\u201D]/g
     , MULTI_SPACES = /\s{2,}/g
-    , NON_ASCII_CHARS = /[^\x00-\x7F]/g;
+    , NON_ASCII_CHARS = /[^\x00-\x7F\x80-\xFF]/g;
 
   filePath = filePath.replace( /\(/g, '\\(' );
   filePath = filePath.replace( /\)/g, '\\)' );

--- a/lib/extractors/pptx.js
+++ b/lib/extractors/pptx.js
@@ -10,7 +10,7 @@ var extractText = function( filePath, options, cb ) {
     , SINGLE_QUOTES = /[\u2018|\u2019]/g
     , DOUBLE_QUOTES = /[\u201C|\u201D]/g
     , MULTI_SPACES = /\s{2,}/g
-    , NON_ASCII_CHARS = /[^\x00-\x7F]/g;
+    , NON_ASCII_CHARS = /[^\x00-\x7F\x80-\xFF]/g;
 
   filePath = filePath.replace( /\(/g, '\\(' );
   filePath = filePath.replace( /\)/g, '\\)' );


### PR DESCRIPTION
Improved the regexps for the docx and pptx extractors as well as on the variables for the cleanseText function in extract.js to support latin accented characters (Unicode range: \x80 - \xFF ).
