### PR TITLE
check if tag has child nodes in pptx, xlsx, and docx before attempting t...

### DIFF
--- a/lib/extractors/docx.js
+++ b/lib/extractors/docx.js
@@ -41,7 +41,7 @@ var extractText = function( filePath, options, cb ) {
         var ts = xpath.select( "//*[local-name()='t' or local-name()='tab' or local-name()='br']", paragraph );
         var localText = "";
         ts.forEach( function ( t ) {
-          if ( t.localName === "t" ) {
+          if ( t.localName === "t" && t.childNodes.length > 0 ) {
             localText += t.childNodes[0].data;
           } else {
             if ( t.localName === "tab" || t.localName === "br" ) {

--- a/lib/extractors/pptx.js
+++ b/lib/extractors/pptx.js
@@ -56,7 +56,7 @@ var extractText = function( filePath, options, cb ) {
         var ts = xpath.select( "//*[local-name()='t' or local-name()='tab' or local-name()='br']", paragraph );
         var localText = "";
         ts.forEach( function ( t ) {
-          if ( t.localName === "t" ) {
+          if ( t.localName === "t" && t.childNodes.length > 0 ) {
             localText += t.childNodes[0].data;
           } else {
             if ( t.localName === "tab" || t.localName === "br" ) {

--- a/lib/extractors/xlsx.js
+++ b/lib/extractors/xlsx.js
@@ -35,7 +35,7 @@ var extractText = function( filePath, options, cb ) {
 
       var textStrs = [];
       textTags.forEach(function (tag) {
-        if ( tag.localName !== 'v' || tag.parentNode.getAttribute('t') !== 's' )	// ignore shared-string keys
+        if ( ( tag.localName !== 'v' || tag.parentNode.getAttribute('t') !== 's' ) && tag.childNodes.length > 0 )	// ignore shared-string keys
           textStrs.push( tag.childNodes[0].data.trim() );
       });
 


### PR DESCRIPTION
Had a pptx file that came in today that crashed our backend server. Had a t node that had no children, so when trying to access `childNode[0]` the module crashes.
