### PR TITLE
use J as a binary instead of loading the module ( 120 + MBs )

### DIFF
--- a/lib/extractors/xls.js
+++ b/lib/extractors/xls.js
@@ -1,30 +1,23 @@
-var path = require( 'path' )
-  , J = require( 'j' );
+var exec = require( 'child_process' ).exec
+    , path = require( 'path' );
 
 var extractText = function( filePath, options, cb ) {
-  var CSVs;
+    var jBin = path.join( __dirname, '../../node_modules/j/bin/j.njs' ) + ' ' + filePath;
+    exec(jBin, function ( error, stdout, stderr ) {
+        if ( error !== null ) {
+            error = new Error("Could not extract " + path.basename( filePath ) + ", " + error);
+            cb( error, null );
+            return;
+        }
 
-  try {
-    var wb = J.readFile( filePath );
-    CSVs = J.utils.to_csv(wb);
-  } catch ( error ) {
-    error = new Error("Could not extract " + path.basename( filePath ) + ", " + error);
-    cb( error, null );
-    return;
-  }
-
-  var result = '';
-  Object.keys( CSVs ).forEach( function( key ) {
-    result += CSVs[ key ];
-  });
-
-  cb( null, result );
+        cb( null, stdout );
+    });
 };
 
 module.exports = {
-  types: ["application/vnd.ms-excel",
-          "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-          "application/vnd.ms-excel.sheet.binary.macroEnabled.12",
-          "application/vnd.ms-excel.sheet.macroEnabled.12"],
-  extract: extractText
+    types: ["application/vnd.ms-excel",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/vnd.ms-excel.sheet.binary.macroEnabled.12",
+        "application/vnd.ms-excel.sheet.macroEnabled.12"],
+    extract: extractText
 };

--- a/test/extract_test.js
+++ b/test/extract_test.js
@@ -83,7 +83,7 @@ describe('textract', function() {
       textract(filePath, function( error ) {
         expect(error).to.be.an('object');
         expect(error.message).to.be.a('string');
-        expect(error.message.substring(0,45)).to.eql("Could not extract notaxlsx.xlsx, TypeError: C");
+        expect(error.message.substring(0,41)).to.eql("Could not extract notaxlsx.xlsx, Error: C");
         done();
       });
     });


### PR DESCRIPTION
Addresses issue #21. Slower than before (1), but avoids loading over 120 MB into memory.

I looked for a way to "unload" a module, so we could include it only at "extract" time then unload it when finished with it but everything that I was able to find didn't free up the memory.
1. I benchmarked around 120 ms before, 775 ms now on an i5-3570K 3.4 GHz, 3.8 turbo.
