### PR TITLE
pipe jBin to sed to remove trailing empty columns

### DIFF
--- a/lib/extractors/xls.js
+++ b/lib/extractors/xls.js
@@ -7,8 +7,7 @@ var extractText = function( filePath, options, cb ) {
   var sedCmd = 'sed -';
   sedCmd += process.platform === 'darwin' ? 'E' : 'r';
   sedCmd += " 's/,+$//g'";
-  console.log(sedCmd);
-  exec(jBin, + ' | ' + sedCmd,
+  exec(jBin + ' | ' + sedCmd,
     function ( error, stdout, stderr ) {
       if ( error !== null ) {
         error = new Error("Could not extract " + path.basename( filePath ) + ", " + error.message);

--- a/lib/extractors/xls.js
+++ b/lib/extractors/xls.js
@@ -4,7 +4,10 @@ var exec = require( 'child_process' ).exec
 
 var extractText = function( filePath, options, cb ) {
   var jBin = path.join( __dirname, '../../node_modules/j/bin/j.njs' ) + ' ' + filePath;
-  exec(jBin + " | sed -r 's/,+$//g'",
+  var sedCmd = 'sed -';
+  sedCmd += process.platform === 'darwin' ? 'E' : 'r';
+  sedCmd += "'s/,+$//g'";
+  exec(jBin + ' | ' + sedCmd,
     function ( error, stdout, stderr ) {
       if ( error !== null ) {
         error = new Error("Could not extract " + path.basename( filePath ) + ", " + error.message);

--- a/lib/extractors/xls.js
+++ b/lib/extractors/xls.js
@@ -4,7 +4,7 @@ var exec = require( 'child_process' ).exec
 
 var extractText = function( filePath, options, cb ) {
   var jBin = path.join( __dirname, '../../node_modules/j/bin/j.njs' ) + ' ' + filePath;
-  exec(jBin,
+  exec(jBin + " | sed -r 's/,+$//g'",
     function ( error, stdout, stderr ) {
       if ( error !== null ) {
         error = new Error("Could not extract " + path.basename( filePath ) + ", " + error.message);

--- a/lib/extractors/xls.js
+++ b/lib/extractors/xls.js
@@ -6,8 +6,9 @@ var extractText = function( filePath, options, cb ) {
   var jBin = path.join( __dirname, '../../node_modules/j/bin/j.njs' ) + ' ' + filePath;
   var sedCmd = 'sed -';
   sedCmd += process.platform === 'darwin' ? 'E' : 'r';
-  sedCmd += "'s/,+$//g'";
-  exec(jBin + ' | ' + sedCmd,
+  sedCmd += " 's/,+$//g'";
+  console.log(sedCmd);
+  exec(jBin, + ' | ' + sedCmd,
     function ( error, stdout, stderr ) {
       if ( error !== null ) {
         error = new Error("Could not extract " + path.basename( filePath ) + ", " + error.message);


### PR DESCRIPTION
I had a problem where XLS and XLSX files had reference to a column number way off in the distance with nothing in it (probably from someone applying formatting an entire row). I started hitting max buffer limits, and I couldn't even find a number that would handle it without hitting it! So instead I pipe the output of jBin to sed and remove all the trailing empty columns in a row.

I also opened an issue with J [here](https://github.com/SheetJS/js-xlsx/issues/182), and it sounds like there might eventually be a switch to have it to this itself, or even be the default behaviour, so this could be removed when that becomes available.
