### PR TITLE
Correct contradictory documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Note, if any of the requirements below are missing, textract will run and extrac
 
 Configuration can be passed into textract.  The following configuration options are available
 
-* `preserveLineBreaks`: By default textract does NOT preserve line breaks. Pass this in as `true` and textract will not strip any line breaks.
+* `preserveLineBreaks`: By default textract preserves line breaks. Pass this in as `false` and textract will strip any line breaks.
 * `disableCatdocWordWrap`: catdoc used to extract .doc/docx files by default formats output for console by breaking lines after 72 characters. Set this to `true` and with `preserveLineBreaks` you will get clean paragraphs.
 * `exec`: Some extractors (dxf) use node's `exec` functionality. This setting allows for providing [config to `exec` execution](http://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback). One reason you might want to provide this config is if you are dealing with very large files. You might want to increase the `exec` `maxBuffer` setting.
 * `[ext].exec`: Each extractor can take specific exec config. Keep in mind many extractors are responsible for extracting multiple types, so, for instance, the `odt` extractor is what you would configure for `odt` and `odg`/`odt` etc.  Check [the extractors](https://github.com/dbashford/textract/tree/master/lib/extractors) to see which you want to specifically configure. At the bottom of each is a list of `types` for which the extractor is responsible.


### PR DESCRIPTION
Line 51 of the Readme disagrees with line 71. Per the [source code](https://github.com/dbashford/textract/blob/5cc50dd9c3a4f76680b3737170645598b401ec64/lib/cli.js#L14) line 71 is correct