### PR TITLE
Remove disableCatdocWordWrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ Note, if any of the requirements below are missing, textract will run and extrac
 Configuration can be passed into textract.  The following configuration options are available
 
 * `preserveLineBreaks`: By default textract does NOT preserve line breaks. Pass this in as `true` and textract will not strip any line breaks.
-* `disableCatdocWordWrap`: catdoc used to extract .doc/docx files by default formats output for console by breaking lines after 72 characters. Set this to `true` and with `preserveLineBreaks` you will get clean paragraphs.
 * `exec`: Some extractors (dxf) use node's `exec` functionality. This setting allows for providing [config to `exec` execution](http://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback). One reason you might want to provide this config is if you are dealing with very large files. You might want to increase the `exec` `maxBuffer` setting.
 * `[ext].exec`: Each extractor can take specific exec config. Keep in mind many extractors are responsible for extracting multiple types, so, for instance, the `odt` extractor is what you would configure for `odt` and `odg`/`odt` etc.  Check [the extractors](https://github.com/dbashford/textract/tree/master/lib/extractors) to see which you want to specifically configure. At the bottom of each is a list of `types` for which the extractor is responsible.
 * `tesseract.lang`: A pass-through to tesseract allowing for setting of language for extraction. ex: `{ tesseract: { lang:"chi_sim" } }`

--- a/bin/textract
+++ b/bin/textract
@@ -8,7 +8,6 @@ var path = require('path')
            "  textract pathToFile\n\n" +
            "Flags:\n" +
            "  preserveLineBreaks: true/false (default: true)\n" +
-           "  disableCatdocWordWrap: true/false (default: false)\n" +
            "  exec.?: allows for passing in node exec parameters, http://nodejs.org/api/child_process.html#child_process_child_process_exec_command_options_callback\n" +
            "  [ext].exec.?: allows for passing in node exec parameters for just a single extension\n" +
            "  tesseract.lang: A pass-through to tesseract allowing for setting of language for extraction\n\n"+

--- a/lib/extractors/doc.js
+++ b/lib/extractors/doc.js
@@ -10,9 +10,7 @@ var extractText = function( filePath, options, cb ) {
     , catdoc
     , catdocArgs = [ filePath ];
 
-  if (options.disableCatdocWordWrap === false) {
-    catdocArgs.push( '-w' );
-  }
+  catdocArgs.push( '-w' );
 
   catdoc = spawn( "catdoc", catdocArgs );
 

--- a/test/extract_test.js
+++ b/test/extract_test.js
@@ -86,10 +86,7 @@ describe('textract', function() {
 
     it('will extract text preserving line breaks without word wrap', function(done) {
       var docPath = path.join( __dirname, "files", "multiple-long-paragraphs.doc" );
-      fromFileWithPath(docPath, {
-        preserveLineBreaks: true,
-        disableCatdocWordWrap: false
-      }, function( error, text ) {
+      fromFileWithPath(docPath, {preserveLineBreaks: true}, function( error, text ) {
         expect(text.match(/\r\n|\n/g).length).to.eql(3);
         expect(error).to.be.null;
         done();


### PR DESCRIPTION
Having this as an option makes no sense. We should always pass the -w
flag to catdoc to prevent it inserting line breaks every 72 characters.
With -w passed catdoc will emit a line break whenever it encounters one
in the document (e.g. at the end of a paragraph.)

Control over wether the line breaks are included in the final output is
then determined by the preserveLineBreaks option

See #39