### PR TITLE
Fix all CLI options being set to false unless set to true 

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -4,12 +4,6 @@ var path = require( 'path' )
 module.exports = function( filePath, flags ) {
   filePath = path.resolve( process.cwd(), filePath );
 
-  for (var flag in flags) {
-    if (flags[flag] !== undefined) {
-      flags[flag] = ( flags[flag] === "true" );
-    }
-  }
-
   if ( flags.preserveLineBreaks === undefined ) {
     flags.preserveLineBreaks = true;
   }


### PR DESCRIPTION
The changes made in https://github.com/dbashford/textract/pull/39 clobber any option passed at the command line. In light of https://github.com/dbashford/textract/pull/54 this code is unnecessary anyway.

Should #54 not be merged I will update this PR to add a default setting for disableCatdocWordWrap