### PR TITLE
Fixed regex for trimming multiple spaces

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -2,7 +2,7 @@ var exec = require('child_process').exec;
 
 var SINGLE_QUOTES = /[\u2018|\u2019]/g
   , DOUBLE_QUOTES = /[\u201C|\u201D]/g
-  , MULTI_SPACES = /\s{2,}/g
+  , MULTI_SPACES = /[^\S\r\n]{2,}/g
   , NON_ASCII_CHARS = /[^\x00-\x7F\x80-\xFF]/g
   ;
 

--- a/test/util_test.js
+++ b/test/util_test.js
@@ -1,0 +1,11 @@
+var util = require('../lib/util');
+
+describe('textract util', function() {
+
+  it('should normalize text output', function() {
+    var text = "    “” ‘’ ą  \n\n some text";
+    var result = util.replaceTextChars(text);
+    expect(result).to.equal("\"\" '' \n\n some text");
+  });
+
+});


### PR DESCRIPTION
`\s` matches for any whitespace including line breaks. This removed new lines when there was two or more and broke `preserveLineBreaks` option.