### PR TITLE
Handle yauzl Zipfile 'error' emit

### DIFF
--- a/lib/extractors/docx.js
+++ b/lib/extractors/docx.js
@@ -63,6 +63,10 @@ var extractText = function( filePath, options, cb ) {
         processEnd();
       }
     });
+
+    zipfile.on('error', function (err) {
+      cb(err);
+    });
   });
 };
 

--- a/lib/extractors/odt.js
+++ b/lib/extractors/odt.js
@@ -46,6 +46,10 @@ var extractText = function( filePath, options, cb ) {
         });
       }
     });
+
+    zipfile.on('error', function (err) {
+      cb(err);
+    });
   });
 };
 

--- a/lib/extractors/pptx.js
+++ b/lib/extractors/pptx.js
@@ -74,6 +74,10 @@ var extractText = function( filePath, options, cb ) {
         });
       }
     });
+
+    zipfile.on('error', function (err) {
+      cb(err);
+    });
   });
 };
 


### PR DESCRIPTION
If yauzl fails while extracting the content of the zipfile, it emits 'error', and there's no handling at all if that occurs on textract.
I faced the problem when I passed a corrupted .docx file to textract and the server  'blew up' :).
This was a quick fix. Maybe I'm missing other stuff.