### PR TITLE
fixes removal of double quotes

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -6,8 +6,8 @@ var fs = require( 'fs' )
   , extensionExtractors = {}
   , typeExtractors = {}
   , regexExtractors = []
-  , WHITELIST_PRESERVE_LINEBREAKS = /[^A-Za-z\x80-\xFF 0-9 \u2018\u2019\u2026 \u00C0-\u1FFF \u2C00-\uD7FF \.,\?""!@#\$%\^&\*\(\)-_=\+;:<>\/\\\|\}\{\[\]`~'-\w\n\r]*/g
-  , WHITELIST_STRIP_LINEBREAKS = /[^A-Za-z\x80-\xFF 0-9 \u2018\u2019\u2026 \u00C0-\u1FFF \u2C00-\uD7FF \.,\?""!@#\$%\^&\*\(\)-_=\+;:<>\/\\\|\}\{\[\]`~'-\w]*/g
+  , WHITELIST_PRESERVE_LINEBREAKS = /[^A-Za-z\x80-\xFF 0-9 \u2018\u2019\u201C|\u201D\u2026 \u00C0-\u1FFF \u2C00-\uD7FF \.,\?""!@#\$%\^&\*\(\)-_=\+;:<>\/\\\|\}\{\[\]`~'-\w\n\r]*/g
+  , WHITELIST_STRIP_LINEBREAKS = /[^A-Za-z\x80-\xFF 0-9 \u2018\u2019\u201C|\u201D\u2026 \u00C0-\u1FFF \u2C00-\uD7FF \.,\?""!@#\$%\^&\*\(\)-_=\+;:<>\/\\\|\}\{\[\]`~'-\w]*/g
   , SINGLE_QUOTES = /[\u2018|\u2019]/g
   , DOUBLE_QUOTES = /[\u201C|\u201D]/g
   , MULTIPLE_SPACES = /[ \t\v\u00A0]{2,}/g // multiple spaces, tabs, vertical tabs, non-breaking space


### PR DESCRIPTION
It seems that ```WHITELIST_PRESERVE_LINEBREAKS``` and ```WHITELIST_STRIP_LINEBREAKS``` were removing double quotes, despite their appearance later being fixed by ```DOUBLE_QUOTES```. The new regex values skip over the double quotes, just like they do for single quotes.