### PR TITLE
Fix check for antiword binary

### DIFF
--- a/lib/extractors/doc.js
+++ b/lib/extractors/doc.js
@@ -37,7 +37,8 @@ function testForBinary( options, cb ) {
     function( error /* , stdout, stderr */ ) {
       var msg;
       if ( error !== null && error.message &&
-          error.message.indexOf( 'antiword: No such file or directory' ) === -1 ) {
+        error.message.indexOf( 'antiword: No such file or directory' ) !== -1 ||
+        error.message.indexOf( 'antiword: not found' ) !== -1 ) {
         msg = 'INFO: \'antiword\' does not appear to be installed, ' +
          'so textract will be unable to extract DOCs.';
         cb( false, msg );


### PR DESCRIPTION
We are checking for the existence of the string ‘antiword: No such file
or directory’ not its absence so the test should be !== -1
If checking for === -1 we will also fail here when the binary exists
but the file is not a word doc (as is the case in the testForBinary
function)

Also add a check for `antiword: not found` as that is the error message
I receive on my platform (Ubuntu 16.04)