### PR TITLE
Revert "use J as a binary instead of loading the module ( 120 + MBs )"

### DIFF
--- a/lib/extractors/xls.js
+++ b/lib/extractors/xls.js
@@ -1,22 +1,26 @@
-var exec = require( 'child_process' ).exec
-  , path = require( 'path' )
+var path = require( 'path' )
+  , J = require( 'j' )
   ;
 
 function extractText( filePath, options, cb ) {
-  var jBin = path.join( __dirname, '../../node_modules/j/bin/j.njs' ) + ' ' + filePath;
-  exec( jBin,
-    function( error, stdout /* , stderr */ ) {
-      if ( error !== null ) {
-        error = new Error( 'Could not extract ' +
-          path.basename( filePath ) + ', ' + error.message );
-        cb( error, null );
-        return;
-      }
+  var CSVs;
 
-      cb( null, stdout );
-    }
-  );
-}
+  try {
+    var wb = J.readFile( filePath );
+    CSVs = J.utils.to_csv(wb);
+  } catch ( error ) {
+    error = new Error("Could not extract " + path.basename( filePath ) + ", " + error);
+    cb( error, null );
+    return;
+  }
+
+  var result = '';
+  Object.keys( CSVs ).forEach( function( key ) {
+    result += CSVs[ key ];
+  });
+
+  cb( null, result );
+};
 
 module.exports = {
   types: ['application/vnd.ms-excel',

--- a/test/extract_test.js
+++ b/test/extract_test.js
@@ -190,7 +190,7 @@ describe('textract', function() {
       fromFileWithPath(filePath, function( error ) {
         expect(error).to.be.an('object');
         expect(error.message).to.be.a('string');
-        expect(error.message.substring(0,41)).to.eql("Could not extract notaxlsx.xlsx, Command ");
+        expect(error.message.substring(0,43)).to.eql("Could not extract notaxlsx.xlsx, Error: PRN");
         done();
       });
     });


### PR DESCRIPTION
This reverts commit 6e35e0ad59815be11d5f82f2798231d11331f0ea made in https://github.com/dbashford/textract/pull/22

As I mentioned in a comment on that pull request the way npm v3 flattens dependencies means we can no longer rely on the j binary being in a consistent location relative to this package. I also think executing J in a separate process is the wrong way to go.

This change necessarily breaks #37 as well however without it `textract` can't be used as a dependency within another project to extract text from spreadsheets

