### PR TITLE
add got library error handling

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -137,6 +137,7 @@ function fromUrl( url, options, cb ) {
           options.typeOverride = response.headers['content-type'].split( /;/ )[0];
         }
       })
+      .on ( 'error', typeof options === 'function' ? options : cb )
       .pipe( file );
   } else {
     _returnArgsError( arguments );


### PR DESCRIPTION
Currently it is impossible to catch errors from **got** library when using **textract.fromUrl** method.
E.g. when the url is broken or the server is unavailable. PR passes those errors to the provided callback.
