### PR TITLE
Fix: catch unhandled exception in text extractor

### DIFF
--- a/lib/extractors/text.js
+++ b/lib/extractors/text.js
@@ -10,8 +10,12 @@ function extractText( filePath, options, cb ) {
       cb( error, null );
       return;
     }
-    encoding = jschardet.detect( data ).encoding.toLowerCase();
-    decoded = iconv.decode( data, encoding );
+    try {
+      encoding = jschardet.detect( data ).encoding.toLowerCase();
+      decoded = iconv.decode( data, encoding );
+    } catch ( e ) {
+      cb( e );
+    }
     cb( null, decoded );
   });
 }

--- a/lib/extractors/text.js
+++ b/lib/extractors/text.js
@@ -14,7 +14,7 @@ function extractText( filePath, options, cb ) {
       encoding = jschardet.detect( data ).encoding.toLowerCase();
       decoded = iconv.decode( data, encoding );
     } catch ( e ) {
-      cb( e );
+      return cb( e );
     }
     cb( null, decoded );
   });


### PR DESCRIPTION
I've added a try/catch around the source of an unhandled exception that I discovered while textract'ing a few thousand files. If need be, I will find the exact cause and create a test case. Please let me know. 