### PR TITLE
add options for doc extractor

### DIFF
--- a/lib/extractors/doc.js
+++ b/lib/extractors/doc.js
@@ -5,7 +5,7 @@ var exec = require( 'child_process' ).exec
   ;
 
 function extractText( filePath, options, cb ) {
-  exec( 'antiword -m UTF-8.txt "' + filePath + '"',
+  exec( 'antiword -m UTF-8.txt "' + filePath + '"', options.exec, 
     function( error, stdout /* , stderr */ ) {
       var err;
       if ( error ) {
@@ -31,7 +31,7 @@ function testForBinary( options, cb ) {
     return;
   }
 
-  exec( 'antiword -m UTF-8.txt ' + __filename,
+  exec( 'antiword -m UTF-8.txt ' + __filename, options.exec, 
     function( error /* , stdout, stderr */ ) {
       var msg;
       if ( error !== null && error.message &&

--- a/lib/extractors/html.js
+++ b/lib/extractors/html.js
@@ -51,9 +51,7 @@ module.exports = {
   types: [
     'text/html',
     'text/xml',
-    'application/xml',
-	'application/rss+xml',
-	'application/atom+xml'
+    'application/xml'
   ],
   extract: extractText,
   extractFromText: extractFromText

--- a/lib/extractors/html.js
+++ b/lib/extractors/html.js
@@ -51,7 +51,9 @@ module.exports = {
   types: [
     'text/html',
     'text/xml',
-    'application/xml'
+    'application/xml',
+	'application/rss+xml',
+	'application/atom+xml'
   ],
   extract: extractText,
   extractFromText: extractFromText

--- a/lib/extractors/pdf.js
+++ b/lib/extractors/pdf.js
@@ -37,7 +37,7 @@ function testForBinary( options, cb ) {
 }
 
 module.exports = {
-  types: ['application/pdf'],
+  types: ['application/pdf', 'application/octed-stream'],
   extract: extractText,
   test: testForBinary
 };


### PR DESCRIPTION
When extracting doc files larger then default stdout max buffer size (200KB), I got the following error:
Error: antiword read of file named [[ myfile.doc ]] failed: Error: stdout maxBuffer exceeded.

So I just passed options.exec to exec. So I'm able to configure maxBuffer, like:

```
textract.fromUrl('http://www.aaa.com/mylargedoc.doc', 
	{exec: {maxBuffer: 400 * 1024}},
	function( error, text ) {});
```