### PR TITLE
Making html extractor accept rss and atom datatypes

### DIFF
--- a/lib/extractors/html.js
+++ b/lib/extractors/html.js
@@ -51,7 +51,9 @@ module.exports = {
   types: [
     'text/html',
     'text/xml',
-    'application/xml'
+    'application/xml',
+	'application/rss+xml',
+	'application/atom+xml'
   ],
   extract: extractText,
   extractFromText: extractFromText

--- a/lib/extractors/html.js
+++ b/lib/extractors/html.js
@@ -52,8 +52,8 @@ module.exports = {
     'text/html',
     'text/xml',
     'application/xml',
-	'application/rss+xml',
-	'application/atom+xml'
+    'application/rss+xml',
+    'application/atom+xml'
   ],
   extract: extractText,
   extractFromText: extractFromText


### PR DESCRIPTION
In reference of text content, RSS and [ATOM](https://msdn.microsoft.com/en-us/library/dd541377.aspx) are just like HTML.