### PR TITLE
Making pdf extractr accept octed-stream

### DIFF
--- a/lib/extractors/pdf.js
+++ b/lib/extractors/pdf.js
@@ -1,4 +1,4 @@
-var path = require( 'path' )
+	var path = require( 'path' )
   , exec = require( 'child_process' ).exec
   , extract = require( 'pdf-text-extract' )
   ;
@@ -37,7 +37,7 @@ function testForBinary( options, cb ) {
 }
 
 module.exports = {
-  types: ['application/pdf'],
+  types: ['application/pdf', 'application/octet-stream'],
   extract: extractText,
   test: testForBinary
 };

--- a/lib/extractors/pdf.js
+++ b/lib/extractors/pdf.js
@@ -1,4 +1,4 @@
-	var path = require( 'path' )
+var path = require( 'path' )
   , exec = require( 'child_process' ).exec
   , extract = require( 'pdf-text-extract' )
   ;


### PR DESCRIPTION
One can argue that the application/octet-stream can be anything. It is true, but when we are talking about text extraction, it is likely to be a PDF file. I don't like the opproach either, but can't figure a better way of dealing with appliction/octed-stream. 