### PR TITLE
Fix "cb is not a function" error on RTFs

### DIFF
--- a/lib/extractors/rtf.js
+++ b/lib/extractors/rtf.js
@@ -31,7 +31,7 @@ function extractText( filePath, options, cb ) {
           path.basename( filePath ) + ' ]] failed: ' + error );
         cb( err, null );
       } else {
-        htmlExtract.extractFromText( stdout.trim(), cb );
+        htmlExtract.extractFromText( stdout.trim(), {}, cb );
       }
     }
   );


### PR DESCRIPTION
Extraction of RTF files would previously fail with `TypeError`: "cb is not a function".

This issue was caused by `html.extractFromText()` accepting an `options` object between the `data` and `cb` parameters (see [html.js:38](https://github.com/dbashford/textract/blob/416c55bf151c6ebe3cb8286c023e6fa10eaaa6df/lib/extractors/html.js#L38)) and `rtf.js` called it without the `options` parameter, resulting in `cb` being set to `undefined`.

This error was mentioned in #149.