### PR TITLE
Return error on unknown text file encoding

### DIFF
--- a/lib/extractors/text.js
+++ b/lib/extractors/text.js
@@ -12,11 +12,11 @@ function extractText( filePath, options, cb ) {
       return;
     }
     try {
-      let detectedEncoding = jschardet.detect( data ).encoding;
-      if (!detectedEncoding) {
-        error = new Error('Could not detect encoding for file named [[ ' +
+      var detectedEncoding = jschardet.detect( data ).encoding;
+      if ( !detectedEncoding ) {
+        error = new Error( 'Could not detect encoding for file named [[ ' +
           path.basename( filePath ) + ' ]]' );
-        cb(error, null);
+        cb( error, null );
         return;
       }
       encoding = detectedEncoding.toLowerCase();

--- a/lib/extractors/text.js
+++ b/lib/extractors/text.js
@@ -1,6 +1,7 @@
 var fs = require( 'fs' )
   , iconv = require( 'iconv-lite' )
   , jschardet = require( 'jschardet' )
+  , path = require( 'path' )
   ;
 
 function extractText( filePath, options, cb ) {
@@ -11,7 +12,15 @@ function extractText( filePath, options, cb ) {
       return;
     }
     try {
-      encoding = jschardet.detect( data ).encoding.toLowerCase();
+      let detectedEncoding = jschardet.detect( data ).encoding;
+      if (!detectedEncoding) {
+        error = new Error('Could not detect encoding for file named [[ ' +
+          path.basename( filePath ) + ' ]]' );
+        cb(error, null);
+        return;
+      }
+      encoding = detectedEncoding.toLowerCase();
+
       decoded = iconv.decode( data, encoding );
     } catch ( e ) {
       cb( e );

--- a/test/extract_test.js
+++ b/test/extract_test.js
@@ -481,6 +481,16 @@ describe( 'textract', function() {
       });
     });
 
+    it( 'will error when .txt file encoding cannot be detected', function( done ) {
+      var filePath = path.join( __dirname, 'files', 'unknown-encoding.txt' );
+      fromFileWithPath( filePath, function( error ) {
+        expect( error ).to.be.an( 'object' );
+        expect( error.message ).to.be.a( 'string' );
+        expect( error.message ).to.eql( 'Could not detect encoding for file named [[ unknown-encoding.txt ]]' );
+        done();
+      });
+    });
+
     it( 'will extract text specifically from a .css file', function( done ) {
       var filePath = path.join( __dirname, 'files', 'css.css' );
       fromFileWithPath( filePath, function( error, text ) {


### PR DESCRIPTION
This PR fixes the case when the encoding detection library cannot detect the file encoding. It will now return an error. I added a test with an empty text file that triggers this case. 

Let me know if you have any questions or other remarks!

