### PR TITLE
Remove temporary files created by the fromUrl method

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -116,7 +116,7 @@ function fromBufferWithName( filePath, bufferContent, options, cb ) {
 }
 
 function fromUrl( url, options, cb ) {
-  var urlNoQueryParams, extname, filePath, fullFilePath, file, href, callbackCalled;
+  var urlNoQueryParams, extname, filePath, fullFilePath, file, href, callbackCalled, _options, _cb;
 
   // allow url to be either a string or to be a
   // Node URL Object: https://nodejs.org/api/url.html
@@ -131,30 +131,29 @@ function fromUrl( url, options, cb ) {
     file = fs.createWriteStream( fullFilePath );
     file.on( 'finish', function() {
       if ( !callbackCalled ) {
-        var _options = options;
-        var _cb = cb;
-        if( typeof options === 'function' ) {
-          _options = function ( error, text ) {
+        _options = options;
+        _cb = cb;
+        if ( typeof options === 'function' ) {
+          _options = function( error, text ) {
             // check if downloaded file still exists
             fs.exists( fullFilePath, ( exists ) => {
               if ( exists ) {
                 // remove the temporary file
-                fs.unlink( fullFilePath, ( xerror ) => {
+                fs.unlink( fullFilePath, ( ) => {
                   options( error, text );
                 });
               } else {
                 options( error, text );
               }
             });
-
           };
         } else if ( typeof cb === 'function' ) {
-          _cb = function ( error, text ) {
+          _cb = function( error, text ) {
             // check if downloaded file still exists
             fs.exists( fullFilePath, ( exists ) => {
               if ( exists ) {
                 // remove the temporary file
-                fs.unlink( fullFilePath, ( xerror ) => {
+                fs.unlink( fullFilePath, ( ) => {
                   cb( error, text );
                 });
               } else {
@@ -176,7 +175,7 @@ function fromUrl( url, options, cb ) {
         }
       })
       .on( 'error', function( error ) {
-        var _cb = ( typeof options === 'function' ) ? options : cb;
+        _cb = ( typeof options === 'function' ) ? options : cb;
         callbackCalled = true;
         _cb( error );
       })

--- a/lib/index.js
+++ b/lib/index.js
@@ -131,7 +131,39 @@ function fromUrl( url, options, cb ) {
     file = fs.createWriteStream( fullFilePath );
     file.on( 'finish', function() {
       if ( !callbackCalled ) {
-        fromFileWithPath( fullFilePath, options, cb );
+        var _options = options;
+        var _cb = cb;
+        if( typeof options === 'function' ) {
+          _options = function ( error, text ) {
+            // check if downloaded file still exists
+            fs.exists( fullFilePath, ( exists ) => {
+              if ( exists ) {
+                // remove the temporary file
+                fs.unlink( fullFilePath, ( xerror ) => {
+                  options( error, text );
+                });
+              } else {
+                options( error, text );
+              }
+            });
+
+          };
+        } else if ( typeof cb === 'function' ) {
+          _cb = function ( error, text ) {
+            // check if downloaded file still exists
+            fs.exists( fullFilePath, ( exists ) => {
+              if ( exists ) {
+                // remove the temporary file
+                fs.unlink( fullFilePath, ( xerror ) => {
+                  cb( error, text );
+                });
+              } else {
+                cb( error, text );
+              }
+            });
+          };
+        }
+        fromFileWithPath( fullFilePath, _options, _cb );
       }
     });
 


### PR DESCRIPTION
Running `textract.fromUrl` on Linux creates temporary files which are not removed after use. With extensive use, the `/tmp` folder can get filled up and might cause problems.