### PR TITLE
Remove temporary file after fromBufferWithMime

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -97,8 +97,13 @@ function fromBufferWithMime( type, bufferContent, options, cb, withPath ) {
        bufferContent &&
        bufferContent instanceof Buffer &&
        ( typeof options === 'function' || typeof cb === 'function' ) ) {
+    if(typeof options === 'function') { cb = options; options = {} }
     _writeBufferToDisk( bufferContent, function( newPath ) {
-      fromFileWithMimeAndPath( type, newPath, options, cb );
+      fromFileWithMimeAndPath( type, newPath, options, function( err, text ) {
+        // Remove temporary file regardless of error, ignore error on unlink
+        fs.unlink(newPath, function() {})
+        if(cb) cb( err, text )
+      });
     });
   } else {
     _returnArgsError( arguments );


### PR DESCRIPTION
This is a serious issue under heavy use. This PR changes fromBufferWithMime to make a best-effort attempt to remove the file when processing is complete.