### PR TITLE
Refactor J to sheetjs xlsx

### DIFF
--- a/lib/extractors/xls.js
+++ b/lib/extractors/xls.js
@@ -1,13 +1,13 @@
 var path = require( 'path' )
-  , J = require( 'j' )
+  , XLSX = require( 'xlsx' )
   ;
 
 function extractText( filePath, options, cb ) {
   var CSVs, wb, result, error;
 
   try {
-    wb = J.readFile( filePath );
-    CSVs = J.utils.to_csv( wb );
+    wb = XLSX.readFile( filePath );
+    CSVs = XLSX.utils.to_csv( wb );
   } catch ( err ) {
     error = new Error( 'Could not extract ' + path.basename( filePath ) + ', ' + err );
     cb( error, null );

--- a/package.json
+++ b/package.json
@@ -47,20 +47,20 @@
     "epub"
   ],
   "dependencies": {
-    "mime": "2.2.0",
-    "pdf-text-extract": "1.3.1",
-    "xpath": "0.0.23",
-    "xmldom": "0.1.27",
-    "j": "0.4.3",
     "cheerio": "1.0.0-rc.2",
-    "marked": "0.6.2",
-    "meow": "3.7.0",
+    "epub2": "1.3.4",
     "got": "5.7.1",
     "html-entities": "1.2.0",
     "iconv-lite": "0.4.15",
     "jschardet": "1.4.1",
-    "yauzl": "2.7.0",
-    "epub2": "1.3.4"
+    "marked": "0.6.2",
+    "meow": "3.7.0",
+    "mime": "2.2.0",
+    "pdf-text-extract": "1.3.1",
+    "xlsx": "0.16.4",
+    "xmldom": "0.1.27",
+    "xpath": "0.0.23",
+    "yauzl": "2.7.0"
   },
   "devDependencies": {
     "chai": "1.5.0",


### PR DESCRIPTION
The library J is deprecated. Fix #186 by migrating to "xlsx" per @SheetJSDev's recommendation.